### PR TITLE
fix: Use pop() instead of element access to get file extension

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -24,7 +24,7 @@ export function getDependantFiles(
   for (const file of files) {
     const ext = file.name.endsWith('js') ?
       module ? 'mjs' : 'cjs' :
-      file.name.split('.')[1];
+      (file.name.split('.').pop() as string);
 
     try {
       const parse = getParser(ext);
@@ -37,6 +37,7 @@ export function getDependantFiles(
         );
       }
     } catch (err) {
+      console.log(err.message);
       if (silent) {
         continue;
       } else {


### PR DESCRIPTION
## Overview

Closes #9

This pull request changes how the CLI extracts file extension from a file name from direct element access `split('.')[1]` to calling the `pop()` function. The previous solution breaks when the file has dot-separated sections on the filename.
