### PR TITLE
fix: Use different script when executing on Windows-based machines

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -69,7 +69,10 @@ export function isInstalled(
   dependency: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const lsCheck = spawn('npm', ['ls', dependency])
+    const lsCheck = spawn(
+      /^win/.test(process.platform) ? 'npm.cmd' : 'npm',
+      ['ls', dependency],
+    )
 
     lsCheck.stdout.on('data', (data) => {
       const isInstalled = data.includes(dependency) &&


### PR DESCRIPTION
## Overview

Closes #11 

This pull request fixes the script when running on Windows by executing a different script `npm.cmd` when checking the package installation. See [here](https://github.com/nodejs/node/issues/3675) for more information about why the script must use `npm.cmd`.

### Caveats

Need to test on even more OS, will this break on any other OSes?
