### PR TITLE
feat: Add React support

### DIFF
--- a/__tests__/parser/cjs.test.ts
+++ b/__tests__/parser/cjs.test.ts
@@ -1,4 +1,4 @@
-import { getCommonJSImportLines } from './../../src/parser/cjs';
+import { getCJSImportLines } from './../../src/parser/cjs';
 
 describe('CommonJS import test', () => {
   it('should be able to distinguish CommonJS imports', () => {
@@ -6,7 +6,7 @@ describe('CommonJS import test', () => {
 
     const app = express()`;
 
-    const dependants = getCommonJSImportLines(content, 'express');
+    const dependants = getCJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -24,7 +24,7 @@ describe('CommonJS import test', () => {
       return a;
     }`;
 
-    const dependants = getCommonJSImportLines(content, 'express');
+    const dependants = getCJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(4);
   });
@@ -42,7 +42,7 @@ describe('CommonJS import test', () => {
       return a;
     }`;
 
-    const dependants = getCommonJSImportLines(content, 'express');
+    const dependants = getCJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(4);
   });
@@ -60,7 +60,7 @@ describe('CommonJS import test', () => {
       return a;
     }`;
 
-    const dependants = getCommonJSImportLines(content, 'express');
+    const dependants = getCJSImportLines(content, 'express');
     expect(dependants.length).toBe(0);
   });
 
@@ -71,7 +71,7 @@ describe('CommonJS import test', () => {
 
     const app = express();`;
 
-    const dependants = getCommonJSImportLines(content, 'express');
+    const dependants = getCJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });

--- a/__tests__/parser/jsx.test.ts
+++ b/__tests__/parser/jsx.test.ts
@@ -1,0 +1,158 @@
+import { getJSXImportLines } from './../../src/parser/jsx';
+
+describe('React JSX test', () => {
+  it('should be able to parse default imports', () => {
+    const content = `import react from 'react';
+
+    function Home() {
+      return <h1>Hello World</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse default imports', () => {
+    const content = `import { useState } from 'react';
+
+    function Home() {
+      const [ping, setPing] = useState(0);
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse aliased imports', () => {
+    const content = `import { useState as a } from 'react';
+
+    function Home() {
+      const [ping, setPing] = a(0);
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse namespace imports', () => {
+    const content = `import * as React from 'react';
+
+    function Home() {
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse unnamed imports', () => {
+    const content = `import 'react';
+
+    function Home() {
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse dynamic imports', () => {
+    const content = `const a = import('react');
+
+    function Home() {
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse imports nested in code', () => {
+    const content = `import * as React from 'react';
+
+    function Home() {
+      const isTest = () => {
+        if (isDevelopment) {
+          const a = require('b');
+        }
+      }
+
+      return <h1>Hello world</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getJSXImportLines(content, 'b');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(6);
+  });
+
+  it('should be able to distinguish false alarms', () => {
+    const content = `const react = "import * as React from 'react';";
+
+    function Home() {
+      const isTest = () => {
+        if (isDevelopment) {
+          const a = require('b');
+        }
+      }
+
+      return <h1>Hello world</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(0);
+  });
+
+  it('should be able to tolerate CommonJS imports', () => {
+    const content = `import express from 'express';
+
+    const react = require('react');
+
+    function Home() {
+      return <h1>Hello world</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(3);
+  });
+
+  it('should be able to parse class-based components', () => {
+    const content = `import * as React from 'react';
+
+    export class Welcome extends React.Component {
+      render() {
+        return <h1>Hello world</h1>;
+      }
+    }`;
+
+    const dependants = getJSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+})

--- a/__tests__/parser/mjs.test.ts
+++ b/__tests__/parser/mjs.test.ts
@@ -1,10 +1,10 @@
-import { getESModulesImportLines } from './../../src/parser/mjs';
+import { getESMImportLines } from './../../src/parser/mjs';
 
 describe('ESModule import test', () => {
   it('should be able to parse default imports', () => {
     const content = 'import express from \'express\'; const app = express();';
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -12,7 +12,7 @@ describe('ESModule import test', () => {
   it('should be able to parse named imports', () => {
     const content = 'import { json } from \'express\'; app.use(json());';
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -20,7 +20,7 @@ describe('ESModule import test', () => {
   it('should be able to parse aliased imports', () => {
     const content = 'import { json as jeson } from \'express\';';
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -28,7 +28,7 @@ describe('ESModule import test', () => {
   it('should be able to parse unnamed imports', () => {
     const content = 'import \'express\';';
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -36,7 +36,7 @@ describe('ESModule import test', () => {
   it('should be able to parse all-module import', () => {
     const content = 'import * as express from \'express\';';
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -44,7 +44,7 @@ describe('ESModule import test', () => {
   it('should be able to parse dynamic imports', () => {
     const content = 'const a = import(\'express\');';
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
@@ -56,7 +56,7 @@ describe('ESModule import test', () => {
       }
     })();`;
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
@@ -64,7 +64,7 @@ describe('ESModule import test', () => {
   it('should be able to parse false alarms', () => {
     const content = `const a = "import express from 'express'";`;
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(0);
   });
 
@@ -75,7 +75,7 @@ describe('ESModule import test', () => {
 
     const app = express();`;
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
@@ -85,7 +85,7 @@ describe('ESModule import test', () => {
 
     const app = express();`;
 
-    const dependants = getESModulesImportLines(content, 'express');
+    const dependants = getESMImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });

--- a/__tests__/parser/ts.test.ts
+++ b/__tests__/parser/ts.test.ts
@@ -1,10 +1,10 @@
-import { getTypeScriptImportLines } from '../../src/parser/ts';
+import { getTSImportLines } from '../../src/parser/ts';
 
 describe('TypeScript parser test', () => {
   it('should be able to parse ES modules import', () => {
     const content = `import express from 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -13,7 +13,7 @@ describe('TypeScript parser test', () => {
   it('should be able to parse all modules import', () => {
     const content = `import * as express from 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -22,7 +22,7 @@ describe('TypeScript parser test', () => {
   it('should be able to parse named imports', () => {
     const content = `import { json } from 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -31,7 +31,7 @@ describe('TypeScript parser test', () => {
   it('should be able to aliased imports', () => {
     const content = `import { json as jeson } from 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -40,7 +40,7 @@ describe('TypeScript parser test', () => {
   it('should be able to parse nameless imports', () => {
     const content = `import 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -49,7 +49,7 @@ describe('TypeScript parser test', () => {
   it('should be able to parse type import', () => {
     const content = `import type { Application } from 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -58,7 +58,7 @@ describe('TypeScript parser test', () => {
   it('should be able to parse dynamic imports', () => {
     const content = `const a = import('express');`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -67,7 +67,7 @@ describe('TypeScript parser test', () => {
   it('should be able to parse CommonJS imports', () => {
     const content = `const a = require('express');`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
@@ -78,7 +78,7 @@ describe('TypeScript parser test', () => {
 
     import express from 'express';`;
 
-    const dependant = getTypeScriptImportLines(content, 'express');
+    const dependant = getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(3);
@@ -91,7 +91,7 @@ describe('TypeScript parser test', () => {
       }
     })();`;
 
-    const dependants = getTypeScriptImportLines(content, 'express');
+    const dependants = getTSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
@@ -103,7 +103,7 @@ describe('TypeScript parser test', () => {
 
     app.lister(3000, () => console.log('hello world'))`;
 
-    const dependants = getTypeScriptImportLines(content, 'express');
+    const dependants = getTSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });

--- a/__tests__/parser/tsx.test.ts
+++ b/__tests__/parser/tsx.test.ts
@@ -1,0 +1,177 @@
+import { getTSXImportLines } from './../../src/parser/tsx';
+
+describe('React TSX test', () => {
+  it('should be able to parse default imports', () => {
+    const content = `import React from 'react';
+
+    export type HomeProps = {
+      foo: string;
+      bar: 'foo';
+    };
+
+    function Home({ foo }: React.PropsWithoutRef<HomeProps>): JSX.Element {
+      return <h1>{foo}</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse default imports', () => {
+    const content = `import * as React from 'react';
+    import { useState } from 'react';
+
+    export type HomeProps = {
+      foo: string;
+      bar: 'foo';
+    };
+
+    function Home({ foo }: React.PropsWithoutRef<HomeProps>): JSX.Element {
+      const [baz, setBaz] = useState(foo);
+      return <h1>{foo}</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(2);
+    expect(dependants[0]).toBe(1);
+    expect(dependants[1]).toBe(2);
+  });
+
+  it('should be able to parse aliased imports', () => {
+    const content = `import * as React from 'react';
+    import { useState as a } from 'react';
+
+    export type HomeProps = {
+      foo: string;
+      bar: 'foo';
+    };
+
+    function Home({ foo }: React.PropsWithoutRef<HomeProps>): JSX.Element {
+      const [baz, setBaz] = a(foo);
+      return <h1>{foo}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(2);
+    expect(dependants[0]).toBe(1);
+    expect(dependants[1]).toBe(2);
+  });
+
+  it('should be able to parse namespace imports', () => {
+    const content = `import * as React from 'react';
+
+    function Home(): JSX.Element {
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse unnamed imports', () => {
+    const content = `import 'react';
+
+    function Home(): JSX.Element {
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse dynamic imports', () => {
+    const content = `const a = import('react');
+
+    function Home(): JSX.Element {
+      return <h1>{ping}</h1>;
+    }
+
+    export default Home;`
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+
+  it('should be able to parse imports nested in code', () => {
+    const content = `import * as React from 'react';
+
+    function Home(): JSX.Element {
+      const isTest = () => {
+        if (isDevelopment) {
+          const a = require('b');
+        }
+      }
+
+      return <h1>Hello world</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getTSXImportLines(content, 'b');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(6);
+  });
+
+  it('should be able to distinguish false alarms', () => {
+    const content = `const react = "import * as React from 'react';";
+
+    function Home(): JSX.Element {
+      const isTest = () => {
+        if (isDevelopment) {
+          const a = require('b');
+        }
+      }
+
+      return <h1>Hello world</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(0);
+  });
+
+  it('should be able to tolerate CommonJS imports', () => {
+    const content = `import express from 'express';
+
+    const react = require('react');
+
+    function Home(): JSX.Element {
+      return <h1>Hello world</h1>;
+    }
+
+    export default Home;`;
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(3);
+  });
+
+  it('should be able to parse class-based components', () => {
+    const content = `import * as React from 'react';
+
+    export class Welcome extends React.Component {
+      render() {
+        return <h1>Hello world</h1>;
+      }
+    }`;
+
+    const dependants = getTSXImportLines(content, 'react');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+})

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "acorn": "^8.4.1",
+    "acorn-jsx": "^5.3.2",
     "acorn-walk": "^8.1.1",
     "chalk": "^4.1.1",
     "glob": "^7.1.7",

--- a/src/import.ts
+++ b/src/import.ts
@@ -37,11 +37,12 @@ export function getDependantFiles(
         );
       }
     } catch (err) {
-      console.log(err.message);
+      const error = err as Error;
+
       if (silent) {
         continue;
       } else {
-        throw new Error(`Failed to parse ${file.path}`);
+        throw new Error(`Failed to parse ${file.path}: ${error.message}`);
       }
     }
   }

--- a/src/parser/cjs.ts
+++ b/src/parser/cjs.ts
@@ -44,7 +44,7 @@ export function parseNode(
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function getCommonJSImportLines(
+export function getCJSImportLines(
   content: string,
   dependency: string,
 ): number[] {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,8 +1,9 @@
+import { FileParser } from '../types';
+
 import { getCommonJSImportLines } from './cjs';
 import { getESModulesImportLines } from './mjs';
-
-import { FileParser } from '../types';
 import { getTypeScriptImportLines } from './ts';
+import { getJSXImportLines } from './jsx';
 
 /**
  * Extension to parser map. Make sure to register the function here
@@ -12,6 +13,7 @@ const PARSER_MAP: Record<string, FileParser> = {
   cjs: getCommonJSImportLines,
   mjs: getESModulesImportLines,
   ts: getTypeScriptImportLines,
+  jsx: getJSXImportLines,
 };
 
 /**

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,19 +1,21 @@
 import { FileParser } from '../types';
 
-import { getCommonJSImportLines } from './cjs';
-import { getESModulesImportLines } from './mjs';
-import { getTypeScriptImportLines } from './ts';
+import { getCJSImportLines } from './cjs';
+import { getESMImportLines } from './mjs';
+import { getTSImportLines } from './ts';
 import { getJSXImportLines } from './jsx';
+import { getTSXImportLines } from './tsx';
 
 /**
  * Extension to parser map. Make sure to register the function here
  * when a new parser is added.
  */
 const PARSER_MAP: Record<string, FileParser> = {
-  cjs: getCommonJSImportLines,
-  mjs: getESModulesImportLines,
-  ts: getTypeScriptImportLines,
+  cjs: getCJSImportLines,
+  mjs: getESMImportLines,
+  ts: getTSImportLines,
   jsx: getJSXImportLines,
+  tsx: getTSXImportLines,
 };
 
 /**

--- a/src/parser/jsx.ts
+++ b/src/parser/jsx.ts
@@ -1,0 +1,87 @@
+import { Parser } from 'acorn';
+import { simple } from 'acorn-walk';
+
+import jsx from 'acorn-jsx';
+
+import type { Node } from 'acorn';
+import type {
+  CallExpression,
+  SourceLocation,
+  ImportExpression,
+  ImportDeclaration,
+} from 'estree';
+
+const parser = Parser.extend(jsx());
+
+/**
+ * Parse JSX nodes for imports to `dependency`
+ *
+ * @param {Node} sourceNode AST representation of the file
+ * @param {string} dependency Package name
+ * @returns {number[]} List of line numbers where `dependency`
+ * is imported.
+ */
+export function parseNode(sourceNode: Node, dependency: string): number[] {
+  const lines: number[] = [];
+
+  simple(sourceNode, {
+    ImportExpression(node: Node) {
+      const importExpr = node as unknown as ImportExpression;
+
+      if (
+        importExpr.source.type === 'Literal' &&
+        importExpr.source.value === dependency
+      ) {
+        lines.push((node.loc as SourceLocation).start.line);
+      }
+    },
+
+    ImportDeclaration(node: Node) {
+      const importDec = node as unknown as ImportDeclaration;
+
+      if (
+        importDec.source.type === 'Literal' &&
+        importDec.source.value === dependency
+      ) {
+        lines.push((node.loc as SourceLocation).start.line);
+      }
+    },
+
+    CallExpression(node: Node) {
+      const callExpr = node as unknown as CallExpression;
+
+      if (
+        callExpr.callee.type === 'Identifier' &&
+        callExpr.callee.name === 'require' &&
+        callExpr.arguments[0].type === 'Literal' &&
+        callExpr.arguments[0].value === dependency
+      ) {
+        lines.push((node.loc as SourceLocation).start.line);
+      }
+    },
+  });
+
+  return lines;
+}
+
+/**
+ * Analyze JSX for all imports to `dependency`
+ *
+ * @param {string} content File content
+ * @param {string} dependency Package name
+ * @returns {number[]} List of line numbers where `dependency`
+ * is imported.
+ */
+export function getJSXImportLines(
+  content: string,
+  dependency: string
+): number[] {
+  const node: Node = parser.parse(content, {
+    ecmaVersion: 'latest',
+    locations: true,
+    allowHashBang: true,
+    sourceType: 'module',
+  });
+
+  return parseNode(node, dependency);
+}

--- a/src/parser/jsx.ts
+++ b/src/parser/jsx.ts
@@ -1,5 +1,5 @@
 import { Parser } from 'acorn';
-import { simple } from 'acorn-walk';
+import { simple, base } from 'acorn-walk';
 
 import jsx from 'acorn-jsx';
 
@@ -58,6 +58,11 @@ export function parseNode(sourceNode: Node, dependency: string): number[] {
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
+    },
+  }, {
+    ...base,
+    JSXElement: () => {
+      // empty
     },
   });
 

--- a/src/parser/mjs.ts
+++ b/src/parser/mjs.ts
@@ -71,7 +71,7 @@ export function parseNode(
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function getESModulesImportLines(
+export function getESMImportLines(
   content: string,
   dependency: string,
 ): number[] {

--- a/src/parser/tsx.ts
+++ b/src/parser/tsx.ts
@@ -68,14 +68,14 @@ function parseNode(
 }
 
 /**
- * Analyze TypeScript file for all imports to `dependency`
+ * Analyze TypeScript's JSX  file for all imports to `dependency`
  *
  * @param {string} content File content
  * @param {string} dependency Package name
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function getTSImportLines(
+export function getTSXImportLines(
   content: string,
   dependency: string,
 ): number[] {
@@ -84,6 +84,7 @@ export function getTSImportLines(
     content,
     ts.ScriptTarget.Latest,
     true,
+    ts.ScriptKind.TSX,
   );
 
   return parseNode(node, dependency);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,7 +1113,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==


### PR DESCRIPTION
## Overview

Closes #20 

This pull request adds `react` support to `dependent`. Both `jsx` and `tsx` are supported.

### Tasks

<!-- List and check the tasks from the referenced issue -->

- [x] Implement `jsx` parser
- [x] Implement `tsx` parser
- [x] Test the functionalities

### Caveats

<!-- Describe a problem with these changes that may or may not become a problem in the future -->
