### PR TITLE
Fix/nested imports

### DIFF
--- a/__tests__/parser/js.test.ts
+++ b/__tests__/parser/js.test.ts
@@ -89,4 +89,14 @@ describe('ESModule import test', () => {
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
+
+  it('should be able to detect nested modules', () => {
+    const content = `import { defineConfig } from 'windicss/helpers';
+
+    export default defineConfig({});`;
+
+    const dependants = getJSImportLines(content, 'windicss');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
 });

--- a/__tests__/parser/jsx.test.ts
+++ b/__tests__/parser/jsx.test.ts
@@ -155,4 +155,14 @@ describe('React JSX test', () => {
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
-})
+
+  it('should be able to detect nested modules', () => {
+    const content = `import { defineConfig } from 'windicss/helpers';
+
+    export default defineConfig({});`;
+
+    const dependants = getJSXImportLines(content, 'windicss');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
+});

--- a/__tests__/parser/ts.test.ts
+++ b/__tests__/parser/ts.test.ts
@@ -107,4 +107,14 @@ describe('TypeScript parser test', () => {
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
+
+  it('should be able to detect nested modules', () => {
+    const content = `import { defineConfig } from 'windicss/helpers';
+
+    export default defineConfig({});`;
+
+    const dependants = getTSImportLines(content, 'windicss');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
 });

--- a/__tests__/parser/tsx.test.ts
+++ b/__tests__/parser/tsx.test.ts
@@ -174,4 +174,14 @@ describe('React TSX test', () => {
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
+
+  it('should be able to detect nested modules', () => {
+    const content = `import { defineConfig } from 'windicss/helpers';
+
+    export default defineConfig({});`;
+
+    const dependants = getTSXImportLines(content, 'windicss');
+    expect(dependants.length).toBe(1);
+    expect(dependants[0]).toBe(1);
+  });
 })

--- a/src/parser/js.ts
+++ b/src/parser/js.ts
@@ -29,7 +29,7 @@ export function parseNode(
 
       if (
         importExpr.source.type === 'Literal' &&
-        importExpr.source.value === dependency
+        importExpr.source.value?.toString().startsWith(dependency)
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
@@ -40,7 +40,7 @@ export function parseNode(
 
       if (
         importDec.source.type === 'Literal' &&
-        importDec.source.value === dependency
+        importDec.source.value?.toString().startsWith(dependency)
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
@@ -53,7 +53,7 @@ export function parseNode(
         callExpr.callee.type === 'Identifier' &&
         callExpr.callee.name === 'require' &&
         callExpr.arguments[0].type === 'Literal' &&
-        callExpr.arguments[0].value === dependency
+        callExpr.arguments[0].value?.toString().startsWith(dependency)
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }

--- a/src/parser/jsx.ts
+++ b/src/parser/jsx.ts
@@ -30,7 +30,7 @@ export function parseNode(sourceNode: Node, dependency: string): number[] {
 
       if (
         importExpr.source.type === 'Literal' &&
-        importExpr.source.value === dependency
+        importExpr.source.value?.toString().startsWith(dependency)
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
@@ -41,7 +41,7 @@ export function parseNode(sourceNode: Node, dependency: string): number[] {
 
       if (
         importDec.source.type === 'Literal' &&
-        importDec.source.value === dependency
+        importDec.source.value?.toString().startsWith(dependency)
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
@@ -54,7 +54,7 @@ export function parseNode(sourceNode: Node, dependency: string): number[] {
         callExpr.callee.type === 'Identifier' &&
         callExpr.callee.name === 'require' &&
         callExpr.arguments[0].type === 'Literal' &&
-        callExpr.arguments[0].value === dependency
+        callExpr.arguments[0].value?.toString().startsWith(dependency)
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }

--- a/src/parser/ts.ts
+++ b/src/parser/ts.ts
@@ -22,7 +22,7 @@ function parseNode(
 
         if (
           specifier.kind === ts.SyntaxKind.StringLiteral &&
-          specifier.getText().slice(1, -1) === dependency
+          specifier.getText().slice(1, -1).startsWith(dependency)
         ) {
           lineNumbers.push(
             sourceNode.getLineAndCharacterOfPosition(node.getStart()).line + 1,
@@ -41,13 +41,13 @@ function parseNode(
         const isImport = expression.kind === ts.SyntaxKind.ImportKeyword &&
           child.length === 1 &&
           child[0].kind === ts.SyntaxKind.StringLiteral &&
-          child[0].getText().slice(1, -1) === dependency;
+          child[0].getText().slice(1, -1).startsWith(dependency);
 
         const isRequire = expression.kind === ts.SyntaxKind.Identifier &&
           expression.getText() === 'require' &&
           child.length === 1 &&
           child[0].kind === ts.SyntaxKind.StringLiteral &&
-          child[0].getText().slice(1, -1) === dependency;
+          child[0].getText().slice(1, -1).startsWith(dependency);
 
         if (isImport || isRequire) {
           lineNumbers.push(

--- a/src/parser/tsx.ts
+++ b/src/parser/tsx.ts
@@ -22,7 +22,7 @@ function parseNode(
 
         if (
           specifier.kind === ts.SyntaxKind.StringLiteral &&
-          specifier.getText().slice(1, -1) === dependency
+          specifier.getText().slice(1, -1).startsWith(dependency)
         ) {
           lineNumbers.push(
             sourceNode.getLineAndCharacterOfPosition(node.getStart()).line + 1,
@@ -41,13 +41,13 @@ function parseNode(
         const isImport = expression.kind === ts.SyntaxKind.ImportKeyword &&
           child.length === 1 &&
           child[0].kind === ts.SyntaxKind.StringLiteral &&
-          child[0].getText().slice(1, -1) === dependency;
+          child[0].getText().slice(1, -1).startsWith(dependency);
 
         const isRequire = expression.kind === ts.SyntaxKind.Identifier &&
           expression.getText() === 'require' &&
           child.length === 1 &&
           child[0].kind === ts.SyntaxKind.StringLiteral &&
-          child[0].getText().slice(1, -1) === dependency;
+          child[0].getText().slice(1, -1).startsWith(dependency);
 
         if (isImport || isRequire) {
           lineNumbers.push(


### PR DESCRIPTION
## Overview

Closes #27

This pull request fixes nested module imports by using `startsWith` instead of equality check for testing dependency identifier.
