### PR TITLE
feat: Add vue support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Checkout to repository
         uses: actions/checkout@v2
       - run: git fetch --unshallow --tags
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.4.0
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Connect workflow to repository
         uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2.4.0
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dependent is a simple utility CLI to find out which files in your NodeJS-based p
 2. ESModules, `.mjs`
 3. TypeScript files, `.ts`
 4. React Extended JavaScript and TypeScript, `.jsx` and `.tsx`
+5. Vue Single File Components, `.vue`
 
 More language support are incoming! Submit your language support ideas [here](https://github.com/Namchee/dependent/issues/new/choose)
 
@@ -127,6 +128,16 @@ Suppress all parsing errors.
 ### `--table`, `-t`
 
 Outputs the result in table-style format instead of line per line format.
+
+## FAQ
+
+### My vue files cannot be parsed. Help!
+
+`dependent` will only support Vue 3 projects. If you asking me to support Vue 2, then the answer is
+
+![No, I don't think I will](https://i.ytimg.com/vi/WIiHrfQq-bo/maxresdefault.jpg)
+
+Vue 3 is already stable, there's no reason to support Vue 2 at all. Feel free to create PR for this though!
 
 ## Motivation
 

--- a/__tests__/parser/js.test.ts
+++ b/__tests__/parser/js.test.ts
@@ -33,7 +33,7 @@ describe('ESModule import test', () => {
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse unnamed imports', () => {
+  it('should be able to parse side-effect imports', () => {
     const content = 'import \'express\';';
 
     const dependants = getJSImportLines(content, 'express');
@@ -168,7 +168,7 @@ describe('React JSX test', () => {
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse unnamed imports', () => {
+  it('should be able to parse side-effect imports', () => {
     const content = `import 'react';
 
     function Home() {

--- a/__tests__/parser/ts.test.ts
+++ b/__tests__/parser/ts.test.ts
@@ -45,7 +45,7 @@ describe('TypeScript parser test', () => {
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse nameless imports', () => {
+  it('should be able to parse side-effect imports', () => {
     const content = `import 'express';`;
 
     const dependant = getTSImportLines(content, 'express');
@@ -205,7 +205,7 @@ describe('React TSX test', () => {
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse unnamed imports', () => {
+  it('should be able to parse side-effect imports', () => {
     const content = `import 'react';
 
     function Home(): JSX.Element {

--- a/__tests__/parser/vue.test.ts
+++ b/__tests__/parser/vue.test.ts
@@ -1,0 +1,5 @@
+describe('Vue parser test', () => {
+  it('passed', () => {
+    expect(1 === 1).toBeTruthy();
+  })
+});

--- a/__tests__/parser/vue.test.ts
+++ b/__tests__/parser/vue.test.ts
@@ -10,8 +10,7 @@ afterEach(() => {
 
 describe('Vue parser test', () => {
   it('should be able to parse ES module import', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import Vue from 'vue';
 
     export default {
@@ -36,8 +35,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse named imports', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import { ref } from 'vue';
 
     export default {
@@ -62,8 +60,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse all module import', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import * as Vue from 'vue';
 
     export default {
@@ -88,8 +85,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse aliased imports', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import { ref as foo } from 'vue';
 
     export default {
@@ -114,8 +110,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse side-effect imports', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import { ref } from 'vue';
     import 'foo/dist/bar.css';
 
@@ -141,8 +136,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse dynamic imports', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import { ref } from 'vue';
 
     async function foo() {
@@ -171,8 +165,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to distinguish false alarms', () => {
-    const content = `
-    <script>
+    const content = `<script>
     import { ref } from 'vue';
     const foo = 'import bar from "baz";';
 
@@ -197,8 +190,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to tolerate CommonJS import', () => {
-    const content = `
-    <script>
+    const content = `<script>
     const vue = require('vue');
 
     export default {
@@ -223,8 +215,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse TypeScript based script', () => {
-    const content = `
-    <script lang="ts">
+    const content = `<script lang="ts">
     import { ref, Ref } from 'vue';
 
     export default {
@@ -249,8 +240,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse TypeScript type imports', () => {
-    const content = `
-    <script lang="ts">
+    const content = `<script lang="ts">
     import { ref } from 'vue';
     import type { Ref } from 'vue';
 
@@ -277,8 +267,7 @@ describe('Vue parser test', () => {
   });
 
   it('should be able to parse `script setup`', () => {
-    const content = `
-    <script setup>
+    const content = `<script setup>
     import _ from 'lodash';
 
     const name = ref(_.capitalize('john doe'));
@@ -292,5 +281,71 @@ describe('Vue parser test', () => {
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse Options API', () => {
+    const content = `<script>
+    import _ from 'lodash';
+
+    export default {
+      data() {
+        return {
+          name: 'john doe',
+        };
+      },
+      computed: {
+        formattedName: () => {
+          return _.capitalize(this.name);
+        },
+      },
+      mounted() {
+        this.doIt();
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'lodash');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse class components', () => {
+    // straightly copy pasted from class component example
+    const content = `<template>
+      <div>
+        <button v-on:click="decrement">-</button>
+        {{ count }}
+        <button v-on:click="increment">+</button>
+      </div>
+    </template>
+
+    <script>
+    import Vue from 'vue';
+    import Component from 'vue-class-component';
+
+    export default class Counter extends Vue {
+      // Class properties will be component data
+      count = 0
+
+      // Methods will be component methods
+      increment() {
+        this.count++
+      }
+
+      decrement() {
+        this.count--
+      }
+    }
+    </script>`;
+
+    const result = getVueImportLines(content, 'vue-class-component');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(11);
   });
 });

--- a/__tests__/parser/vue.test.ts
+++ b/__tests__/parser/vue.test.ts
@@ -1,5 +1,296 @@
+import { jest } from '@jest/globals';
+
+import { getVueImportLines } from '../../src/parser/vue';
+
+jest.useFakeTimers();
+
+afterEach(() => {
+  jest.clearAllTimers();
+});
+
 describe('Vue parser test', () => {
-  it('passed', () => {
-    expect(1 === 1).toBeTruthy();
-  })
+  it('should be able to parse ES module import', () => {
+    const content = `
+    <script>
+    import Vue from 'vue';
+
+    export default {
+      setup() {
+        const name = Vue.ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse named imports', () => {
+    const content = `
+    <script>
+    import { ref } from 'vue';
+
+    export default {
+      setup() {
+        const name = ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse all module import', () => {
+    const content = `
+    <script>
+    import * as Vue from 'vue';
+
+    export default {
+      setup() {
+        const name = Vue.ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse aliased imports', () => {
+    const content = `
+    <script>
+    import { ref as foo } from 'vue';
+
+    export default {
+      setup() {
+        const name = foo('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse side-effect imports', () => {
+    const content = `
+    <script>
+    import { ref } from 'vue';
+    import 'foo/dist/bar.css';
+
+    export default {
+      setup() {
+        const name = ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'foo');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(3);
+  });
+
+  it('should be able to parse dynamic imports', () => {
+    const content = `
+    <script>
+    import { ref } from 'vue';
+
+    async function foo() {
+      const bar = await import('baz');
+    }
+
+    export default {
+      setup() {
+        const name = ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'baz');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(5);
+  });
+
+  it('should be able to distinguish false alarms', () => {
+    const content = `
+    <script>
+    import { ref } from 'vue';
+    const foo = 'import bar from "baz";';
+
+    export default {
+      setup() {
+        const name = ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'baz');
+
+    expect(result.length).toBe(0);
+  });
+
+  it('should be able to tolerate CommonJS import', () => {
+    const content = `
+    <script>
+    const vue = require('vue');
+
+    export default {
+      setup() {
+        const name = vue.ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse TypeScript based script', () => {
+    const content = `
+    <script lang="ts">
+    import { ref, Ref } from 'vue';
+
+    export default {
+      setup() {
+        const name: Ref<string> = ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse TypeScript type imports', () => {
+    const content = `
+    <script lang="ts">
+    import { ref } from 'vue';
+    import type { Ref } from 'vue';
+
+    export default {
+      setup() {
+        const name: Ref<string> = ref('John Doe');
+
+        return {
+          name,
+        };
+      },
+    };
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'vue');
+
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(2);
+    expect(result[1]).toBe(3);
+  });
+
+  it('should be able to parse `script setup`', () => {
+    const content = `
+    <script setup>
+    import _ from 'lodash';
+
+    const name = ref(_.capitalize('john doe'));
+    </script>
+
+    <template>
+      Hello, {{ name }}
+    </template>`;
+
+    const result = getVueImportLines(content, 'lodash');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,7 @@ import type { Config } from '@jest/types';
 
 /** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */
 const config: Config.InitialOptions = {
-  preset: 'ts-jest/presets/js-with-ts-esm',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   verbose: true,
   transform: {},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "build": "rollup -c rollup.config.js",
+    "build:no-minify": "tsc",
     "build:watch": "rollup -c rollup.config.js -w",
     "test": "jest",
     "test:watch": "jest --watch"
@@ -42,6 +43,7 @@
     "@types/yargs": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^4.28.0",
     "@typescript-eslint/parser": "^4.28.0",
+    "@vue/compiler-sfc": "^3.2.6",
     "auto": "^10.30.0",
     "cross-env": "^7.0.3",
     "eslint": "^7.29.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,11 +27,13 @@ export const cli = yargs(hideBin(process.argv))
       '!(node_modules)/**/*.ts',
       '!(node_modules)/**/*.jsx',
       '!(node_modules)/**/*.tsx',
+      '!(node_modules)/**/*.vue',
       '*.js',
       '*.mjs',
       '*.ts',
       '*.jsx',
       '*.tsx',
+      '*.vue',
     ],
   })
   .options({

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2,6 +2,7 @@ import { FileParser } from '../types';
 
 import { getJSImportLines } from './js';
 import { getTSImportLines } from './ts';
+import { getVueImportLines } from './vue';
 
 /**
  * Extension to parser map. Make sure to register the function here
@@ -12,6 +13,7 @@ const PARSER_FUNCTIONS: Record<string, FileParser> = {
   ts: getTSImportLines,
   jsx: getJSImportLines,
   tsx: getTSImportLines,
+  vue: getVueImportLines,
 };
 
 /**

--- a/src/parser/ts.ts
+++ b/src/parser/ts.ts
@@ -17,7 +17,7 @@ try {
     import.meta.url,
   );
   const npmPath = new URL(
-    resolve('globalDirectories.npm.packages', ...basePath),
+    resolve(globalDirectories.npm.packages, ...basePath),
     import.meta.url,
   );
   const yarnPath = new URL(
@@ -121,7 +121,7 @@ export function getTSImportLines(
   dependency: string,
 ): number[] {
   if (!ts) {
-    throw new Error('No typescript parsers available');
+    throw new Error('No Typescript parsers available');
   }
 
   const node = ts.createSourceFile(

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -1,0 +1,71 @@
+import globalDirectories from 'global-dirs';
+import { resolve } from 'path/posix';
+import { getParser } from '.';
+
+let vue: typeof import('@vue/compiler-sfc');
+
+try {
+  const basePath = [
+    '@vue',
+    'compiler-sfc',
+    'dist',
+    'compiler-sfc.cjs.js',
+  ];
+  const localPath = new URL(
+    resolve('node_modules', ...basePath),
+    import.meta.url,
+  );
+  const npmPath = new URL(
+    resolve(globalDirectories.npm.packages, ...basePath),
+    import.meta.url,
+  );
+  const yarnPath = new URL(
+    resolve(globalDirectories.yarn.packages, ...basePath),
+    import.meta.url,
+  );
+
+  const imports = await Promise.allSettled([
+    import(localPath.toString()),
+    import(npmPath.toString()),
+    import(yarnPath.toString()),
+  ]);
+
+  for (const impor of imports) {
+    if (impor.status === 'fulfilled') {
+      vue = impor.value.default as typeof import('@vue/compiler-sfc');
+      break;
+    } else {
+      console.log (impor.reason);
+    }
+  }
+} catch (err) {
+  /* ignore for now */
+}
+
+/**
+ * Analyze Vue file for all imports to `dependency`
+ *
+ * @param {string} content File content
+ * @param {string} dependency Package name
+ * @returns {number[]} List of line numbers where `dependency`
+ * is imported.
+ */
+export function getVueImportLines(
+  content: string,
+  dependency: string,
+): number[] {
+  if (!vue) {
+    throw new Error('No Vue parsers available');
+  }
+
+  const node = vue.parse(content);
+  const script = node.descriptor.script;
+
+  if (script) {
+    const parser = getParser(script.lang || 'js');
+
+    return parser(script.content, dependency);
+  }
+
+  return [];
+}

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -66,8 +66,9 @@ export function getVueImportLines(
     const startingLine = script.loc.start.line;
     const parser = getParser(script.lang || 'js');
 
-    const lines = parser(script.content.trim(), dependency);
-    return lines.map(line => line + startingLine);
+    const lines = parser(script.content, dependency);
+    // -1, since the `<script>` block shouldn't count
+    return lines.map(line => line + startingLine - 1);
   }
 
   return [];

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -59,7 +59,7 @@ export function getVueImportLines(
   }
 
   const node = vue.parse(content);
-  const script = node.descriptor.script;
+  const script = node.descriptor.script ?? node.descriptor.scriptSetup;
 
   if (script) {
     const parser = getParser(script.lang || 'js');

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -1,5 +1,6 @@
 import globalDirectories from 'global-dirs';
-import { resolve } from 'path/posix';
+import path from 'path';
+
 import { getParser } from '.';
 
 let vue: typeof import('@vue/compiler-sfc');
@@ -12,15 +13,15 @@ try {
     'compiler-sfc.cjs.js',
   ];
   const localPath = new URL(
-    resolve('node_modules', ...basePath),
+    path.posix.resolve('node_modules', ...basePath),
     import.meta.url,
   );
   const npmPath = new URL(
-    resolve(globalDirectories.npm.packages, ...basePath),
+    path.posix.resolve(globalDirectories.npm.packages, ...basePath),
     import.meta.url,
   );
   const yarnPath = new URL(
-    resolve(globalDirectories.yarn.packages, ...basePath),
+    path.posix.resolve(globalDirectories.yarn.packages, ...basePath),
     import.meta.url,
   );
 
@@ -62,9 +63,11 @@ export function getVueImportLines(
   const script = node.descriptor.script ?? node.descriptor.scriptSetup;
 
   if (script) {
+    const startingLine = script.loc.start.line;
     const parser = getParser(script.lang || 'js');
 
-    return parser(script.content, dependency);
+    const lines = parser(script.content.trim(), dependency);
+    return lines.map(line => line + startingLine);
   }
 
   return [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#32be33a756f29e278a0d644fa08a2c9e0f88a34c"
   integrity sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==
 
+"@babel/helper-validator-identifier@^7.14.9":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
+  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
@@ -285,6 +290,11 @@
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.8.tgz#66fd41666b2d7b840bd5ace7f7416d5ac60208d4"
   integrity sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==
+
+"@babel/parser@^7.15.0":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
+  integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -407,6 +417,14 @@
   integrity sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.8"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
+  integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -906,6 +924,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
+"@types/estree@^0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.48.tgz#18dc8091b285df90db2f25aa7d906cfc394b7f74"
+  integrity sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==
+
 "@types/glob@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
@@ -1099,6 +1122,73 @@
   dependencies:
     "@typescript-eslint/types" "4.28.4"
     eslint-visitor-keys "^2.0.0"
+
+"@vue/compiler-core@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.6.tgz#7162bb0670273f04566af0d353009187ab577915"
+  integrity sha512-vbwnz7+OhtLO5p5i630fTuQCL+MlUpEMTKHuX+RfetQ+3pFCkItt2JUH+9yMaBG2Hkz6av+T9mwN/acvtIwpbw==
+  dependencies:
+    "@babel/parser" "^7.15.0"
+    "@babel/types" "^7.15.0"
+    "@vue/shared" "3.2.6"
+    estree-walker "^2.0.2"
+    source-map "^0.6.1"
+
+"@vue/compiler-dom@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.6.tgz#3764d7fe1a696e39fb2a3c9d638da0749e369b2d"
+  integrity sha512-+a/3oBAzFIXhHt8L5IHJOTP4a5egzvpXYyi13jR7CUYOR1S+Zzv7vBWKYBnKyJLwnrxTZnTQVjeHCgJq743XKg==
+  dependencies:
+    "@vue/compiler-core" "3.2.6"
+    "@vue/shared" "3.2.6"
+
+"@vue/compiler-sfc@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.6.tgz#d6ab7410cff57081ab627b15a1ea51a1072c7cf1"
+  integrity sha512-Ariz1eDsf+2fw6oWXVwnBNtfKHav72RjlWXpEgozYBLnfRPzP+7jhJRw4Nq0OjSsLx2HqjF3QX7HutTjYB0/eA==
+  dependencies:
+    "@babel/parser" "^7.15.0"
+    "@babel/types" "^7.15.0"
+    "@types/estree" "^0.0.48"
+    "@vue/compiler-core" "3.2.6"
+    "@vue/compiler-dom" "3.2.6"
+    "@vue/compiler-ssr" "3.2.6"
+    "@vue/ref-transform" "3.2.6"
+    "@vue/shared" "3.2.6"
+    consolidate "^0.16.0"
+    estree-walker "^2.0.2"
+    hash-sum "^2.0.0"
+    lru-cache "^5.1.1"
+    magic-string "^0.25.7"
+    merge-source-map "^1.1.0"
+    postcss "^8.1.10"
+    postcss-modules "^4.0.0"
+    postcss-selector-parser "^6.0.4"
+    source-map "^0.6.1"
+
+"@vue/compiler-ssr@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.6.tgz#cadcf199859fa00739f4275b4c85970e4b0abe7d"
+  integrity sha512-A7IKRKHSyPnTC4w1FxHkjzoyjXInsXkcs/oX22nBQ+6AWlXj2Tt1le96CWPOXy5vYlsTYkF1IgfBaKIdeN/39g==
+  dependencies:
+    "@vue/compiler-dom" "3.2.6"
+    "@vue/shared" "3.2.6"
+
+"@vue/ref-transform@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/ref-transform/-/ref-transform-3.2.6.tgz#30b5f1fa77daf9894bc23e6a5a0e3586a4a796b8"
+  integrity sha512-ie39+Y4nbirDLvH+WEq6Eo/l3n3mFATayqR+kEMSphrtMW6Uh/eEMx1Gk2Jnf82zmj3VLRq7dnmPx72JLcBYkQ==
+  dependencies:
+    "@babel/parser" "^7.15.0"
+    "@vue/compiler-core" "3.2.6"
+    "@vue/shared" "3.2.6"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+
+"@vue/shared@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.6.tgz#2c22bae88fe2b7b59fa68a9c9c4cd60bae2c1794"
+  integrity sha512-uwX0Qs2e6kdF+WmxwuxJxOnKs/wEkMArtYpHSm7W+VY/23Tl8syMRyjnzEeXrNCAP0/8HZxEGkHJsjPEDNRuHw==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -1412,6 +1502,11 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -1420,6 +1515,11 @@ bl@^4.1.0:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bottleneck@^2.15.3:
   version "2.19.5"
@@ -1700,6 +1800,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+consolidate@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.16.0.tgz#a11864768930f2f19431660a65906668f5fbdc16"
+  integrity sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==
+  dependencies:
+    bluebird "^3.7.2"
 
 conventional-changelog-core@^4.2.0:
   version "4.2.3"
@@ -2017,6 +2124,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -2274,7 +2386,7 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
-estree-walker@^2.0.1:
+estree-walker@^2.0.1, estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
@@ -2505,6 +2617,13 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+generic-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
+  integrity sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
+  dependencies:
+    loader-utils "^1.1.0"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2751,6 +2870,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-sum@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
+  integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -2825,6 +2949,16 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+icss-replace-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
+  integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
+
+icss-utils@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -3679,6 +3813,13 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -3741,6 +3882,15 @@ load-json-file@^4.0.0:
     parse-json "^4.0.0"
     pify "^3.0.0"
     strip-bom "^3.0.0"
+
+loader-utils@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -3809,6 +3959,13 @@ longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3943,6 +4100,13 @@ meow@^9.0.0:
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
 
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -4031,6 +4195,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nanoid@^3.1.23:
+  version "3.1.25"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
+  integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4397,6 +4566,48 @@ postcss-media-query-parser@^0.2.3:
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
   integrity sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=
 
+postcss-modules-extract-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
+  integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
+
+postcss-modules-local-by-default@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
+  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+  dependencies:
+    icss-utils "^5.0.0"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+postcss-modules-scope@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
+  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
+postcss-modules-values@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
+  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+  dependencies:
+    icss-utils "^5.0.0"
+
+postcss-modules@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.2.2.tgz#5e7777c5a8964ea176919d90b2e54ef891321ce5"
+  integrity sha512-/H08MGEmaalv/OU8j6bUKi/kZr2kqGF6huAW8m9UAgOLWtpFdhA14+gPBoymtqyv+D4MLsmqaF2zvIegdCxJXg==
+  dependencies:
+    generic-names "^2.0.1"
+    icss-replace-symbols "^1.1.0"
+    lodash.camelcase "^4.3.0"
+    postcss-modules-extract-imports "^3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
+    string-hash "^1.1.1"
+
 postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
@@ -4424,7 +4635,7 @@ postcss-scss@^2.1.1:
   dependencies:
     postcss "^7.0.6"
 
-postcss-selector-parser@^6.0.5:
+postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
   integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
@@ -4450,6 +4661,15 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.1.10:
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.6.tgz#2730dd76a97969f37f53b9a6096197be311cc4ea"
+  integrity sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4896,6 +5116,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
 source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -4980,6 +5205,11 @@ stack-utils@^2.0.3:
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+string-hash@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
+  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -5733,6 +5963,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Overview

Closes #34 

This pull request adds VueJS SFC file parsing support. Now, `dependent` will analyze `.vue` files.

### Caveats

Vue 2 is not supported, since we use `@vue/compiler-sfc` as the compiler, which is a Vue 3 compiler.