### PR TITLE
fix: Use path splitter to replace `startsWith` to handle nested modules

### DIFF
--- a/__tests__/parser/js.test.ts
+++ b/__tests__/parser/js.test.ts
@@ -107,6 +107,15 @@ describe('ESModule import test', () => {
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
+
+  it('should be able to distinguish dash separated modules', () => {
+    const content = `import { defineConfig } from 'windicss-helpers';
+
+    export default defineConfig({});`;
+
+    const dependants = getJSImportLines(content, 'windicss');
+    expect(dependants.length).toBe(0);
+  });
 });
 
 describe('React JSX test', () => {

--- a/__tests__/parser/ts.test.ts
+++ b/__tests__/parser/ts.test.ts
@@ -125,6 +125,15 @@ describe('TypeScript parser test', () => {
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
+
+  it('should be able to distinguish dash separated modules', () => {
+    const content = `import { defineConfig } from 'windicss-helpers';
+
+    export default defineConfig({});`;
+
+    const dependants = getTSImportLines(content, 'windicss');
+    expect(dependants.length).toBe(0);
+  });
 });
 
 describe('React TSX test', () => {

--- a/src/parser/js.ts
+++ b/src/parser/js.ts
@@ -33,7 +33,7 @@ export function parseNode(
 
       if (
         importExpr.source.type === 'Literal' &&
-        importExpr.source.value?.toString().startsWith(dependency)
+        importExpr.source.value?.toString().split('/')[0] === dependency
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
@@ -44,7 +44,7 @@ export function parseNode(
 
       if (
         importDec.source.type === 'Literal' &&
-        importDec.source.value?.toString().startsWith(dependency)
+        importDec.source.value?.toString().split('/')[0] === dependency
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }
@@ -57,7 +57,7 @@ export function parseNode(
         callExpr.callee.type === 'Identifier' &&
         callExpr.callee.name === 'require' &&
         callExpr.arguments[0].type === 'Literal' &&
-        callExpr.arguments[0].value?.toString().startsWith(dependency)
+        callExpr.arguments[0].value?.toString().split('/')[0] === dependency
       ) {
         lines.push((node.loc as SourceLocation).start.line);
       }

--- a/src/parser/ts.ts
+++ b/src/parser/ts.ts
@@ -63,7 +63,7 @@ function parseNode(
 
         if (
           specifier.kind === 10 &&
-          specifier.getText().slice(1, -1).startsWith(dependency)
+          specifier.getText().slice(1, -1).split('/')[0] === dependency
         ) {
           lineNumbers.push(
             sourceNode.getLineAndCharacterOfPosition(node.getStart()).line + 1,
@@ -82,13 +82,13 @@ function parseNode(
         const isImport = expression.kind === ts.SyntaxKind.ImportKeyword &&
           child.length === 1 &&
           child[0].kind === ts.SyntaxKind.StringLiteral &&
-          child[0].getText().slice(1, -1).startsWith(dependency);
+          child[0].getText().slice(1, -1).split('/')[0] === dependency;
 
         const isRequire = expression.kind === ts.SyntaxKind.Identifier &&
           expression.getText() === 'require' &&
           child.length === 1 &&
           child[0].kind === ts.SyntaxKind.StringLiteral &&
-          child[0].getText().slice(1, -1).startsWith(dependency);
+          child[0].getText().slice(1, -1).split('/')[0] === dependency;
 
         if (isImport || isRequire) {
           lineNumbers.push(


### PR DESCRIPTION
## Overview

Closes #37 

This pull request fixes nested module handling by using `split('/')` instead of `startsWith` that will fail if a common package name is used by multiple packages that are unrelated yet starts with the said name.