### PR TITLE
feat: Add svelte support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Dependent is a simple utility CLI to find out which files in your NodeJS-based p
 2. ESModules, `.mjs`
 3. TypeScript files, `.ts`
 4. React Extended JavaScript and TypeScript, `.jsx` and `.tsx`
-5. Vue Single File Components, `.vue`
+5. Vue Single File Components, `.vue` (`.js` and `.ts` scripts only)
+6. Svelte Single File Components, `.svelte` (`.js` script only)
 
 More language support are incoming! Submit your language support ideas [here](https://github.com/Namchee/dependent/issues/new/choose)
 

--- a/__tests__/parser/js.test.ts
+++ b/__tests__/parser/js.test.ts
@@ -9,117 +9,117 @@ afterEach(() => {
 });
 
 describe('ESModule import test', () => {
-  it('should be able to parse default imports', () => {
+  it('should be able to parse default imports', async () => {
     const content = 'import express from \'express\'; const app = express();';
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse named imports', () => {
+  it('should be able to parse named imports', async () => {
     const content = 'import { json } from \'express\'; app.use(json());';
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse aliased imports', () => {
+  it('should be able to parse aliased imports', async () => {
     const content = 'import { json as jeson } from \'express\';';
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse side-effect imports', () => {
+  it('should be able to parse side-effect imports', async () => {
     const content = 'import \'express\';';
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse all-module import', () => {
+  it('should be able to parse all-module import', async () => {
     const content = 'import * as express from \'express\';';
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse dynamic imports', () => {
+  it('should be able to parse dynamic imports', async () => {
     const content = 'const a = import(\'express\');';
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse module imports nested in code', () => {
+  it('should be able to parse module imports nested in code', async () => {
     const content = `(async () => {
       if (somethingIsTrue) {
         await import('express');
       }
     })();`;
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
 
-  it('should be able to parse false alarms', () => {
+  it('should be able to parse false alarms', async () => {
     const content = `const a = "import express from 'express'";`;
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(0);
   });
 
-  it('should be able to parse shebanged files', () => {
+  it('should be able to parse shebanged files', async () => {
     const content = `#!/usr/bin/env node
 
     import express from 'express';
 
     const app = express();`;
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
 
-  it('should be able to tolerate CommonJS imports', () => {
+  it('should be able to tolerate CommonJS imports', async () => {
     const content = `const express = require('express');
 
     const app = express();`;
 
-    const dependants = getJSImportLines(content, 'express');
+    const dependants = await await getJSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to detect nested modules', () => {
+  it('should be able to detect nested modules', async () => {
     const content = `import { defineConfig } from 'windicss/helpers';
 
     export default defineConfig({});`;
 
-    const dependants = getJSImportLines(content, 'windicss');
+    const dependants = await getJSImportLines(content, 'windicss');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to distinguish dash separated modules', () => {
+  it('should be able to distinguish dash separated modules', async () => {
     const content = `import { defineConfig } from 'windicss-helpers';
 
     export default defineConfig({});`;
 
-    const dependants = getJSImportLines(content, 'windicss');
+    const dependants = await getJSImportLines(content, 'windicss');
     expect(dependants.length).toBe(0);
   });
 });
 
 describe('React JSX test', () => {
-  it('should be able to parse default imports', () => {
+  it('should be able to parse default imports', async () => {
     const content = `import react from 'react';
 
     function Home() {
@@ -128,12 +128,12 @@ describe('React JSX test', () => {
 
     export default Home;`
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse default imports', () => {
+  it('should be able to parse default imports', async () => {
     const content = `import { useState } from 'react';
 
     function Home() {
@@ -143,12 +143,12 @@ describe('React JSX test', () => {
 
     export default Home;`
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse aliased imports', () => {
+  it('should be able to parse aliased imports', async () => {
     const content = `import { useState as a } from 'react';
 
     function Home() {
@@ -158,12 +158,12 @@ describe('React JSX test', () => {
 
     export default Home;`
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse namespace imports', () => {
+  it('should be able to parse namespace imports', async () => {
     const content = `import * as React from 'react';
 
     function Home() {
@@ -172,12 +172,12 @@ describe('React JSX test', () => {
 
     export default Home;`
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse side-effect imports', () => {
+  it('should be able to parse side-effect imports', async () => {
     const content = `import 'react';
 
     function Home() {
@@ -186,12 +186,12 @@ describe('React JSX test', () => {
 
     export default Home;`
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse dynamic imports', () => {
+  it('should be able to parse dynamic imports', async () => {
     const content = `const a = import('react');
 
     function Home() {
@@ -200,12 +200,12 @@ describe('React JSX test', () => {
 
     export default Home;`
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse imports nested in code', () => {
+  it('should be able to parse imports nested in code', async () => {
     const content = `import * as React from 'react';
 
     function Home() {
@@ -220,16 +220,16 @@ describe('React JSX test', () => {
 
     export default Home;`;
 
-    const dependants = getJSImportLines(content, 'b');
+    const dependants = await getJSImportLines(content, 'b');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(6);
   });
 
-  it('should be able to distinguish false alarms', () => {
+  it('should be able to distinguish false alarms', async () => {
     const content = `const react = "import * as React from 'react';";
 
     function Home() {
-      const isTest = () => {
+      const isTest = async () => {
         if (isDevelopment) {
           const a = require('b');
         }
@@ -240,11 +240,11 @@ describe('React JSX test', () => {
 
     export default Home;`;
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(0);
   });
 
-  it('should be able to tolerate CommonJS imports', () => {
+  it('should be able to tolerate CommonJS imports', async () => {
     const content = `import express from 'express';
 
     const react = require('react');
@@ -255,12 +255,12 @@ describe('React JSX test', () => {
 
     export default Home;`;
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
 
-  it('should be able to parse class-based components', () => {
+  it('should be able to parse class-based components', async () => {
     const content = `import * as React from 'react';
 
     export class Welcome extends React.Component {
@@ -269,17 +269,17 @@ describe('React JSX test', () => {
       }
     }`;
 
-    const dependants = getJSImportLines(content, 'react');
+    const dependants = await getJSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to detect nested modules', () => {
+  it('should be able to detect nested modules', async () => {
     const content = `import { defineConfig } from 'windicss/helpers';
 
     export default defineConfig({});`;
 
-    const dependants = getJSImportLines(content, 'windicss');
+    const dependants = await getJSImportLines(content, 'windicss');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });

--- a/__tests__/parser/svelte.test.ts
+++ b/__tests__/parser/svelte.test.ts
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+
+jest.useFakeTimers();
+
+afterEach(() => {
+  jest.clearAllTimers();
+});
+
+describe('Svelte parser test', () => {
+  it('should pass', () => {
+    expect(1).toBe(1);
+  })
+});

--- a/__tests__/parser/svelte.test.ts
+++ b/__tests__/parser/svelte.test.ts
@@ -1,5 +1,7 @@
 import { jest } from '@jest/globals';
 
+import { getSvelteImportLines } from './../../src/parser/svelte';
+
 jest.useFakeTimers();
 
 afterEach(() => {
@@ -7,7 +9,161 @@ afterEach(() => {
 });
 
 describe('Svelte parser test', () => {
-  it('should pass', () => {
-    expect(1).toBe(1);
-  })
+  it('should be able to parse ES module import', async () => {
+    const content = `<script>
+      import _ from 'lodash';
+
+      let name = 'john doe';
+
+      $: formatted = _.capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'lodash');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse named imports', async () => {
+    const content = `<script>
+    import { capitalize } from 'lodash';
+
+    let name = 'john doe';
+
+    $: formatted = capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'lodash');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse all module import', async () => {
+    const content = `<script>
+    import * as _ from 'lodash';
+
+    let name = 'john doe';
+
+    $: formatted = _.capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'lodash');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse aliased imports', async () => {
+    const content = `<script>
+    import { capitalize as cap } from 'lodash';
+
+    let name = 'john doe';
+
+    $: formatted = cap(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'lodash');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(2);
+  });
+
+  it('should be able to parse side-effect imports', async () => {
+    const content = `<script>
+    import _ from 'lodash';
+    import 'foo/bar/baz.css'
+
+    let name = 'john doe';
+
+    $: formatted = _.capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'foo');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(3);
+  });
+
+  it('should be able to parse dynamic imports', async () => {
+    const content = `<script>
+    import _ from 'lodash';
+
+    async function fakeLoader() {
+      await import('foo');
+    }
+
+    let name = 'john doe';
+
+    $: formatted = _.capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'foo');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(5);
+  });
+
+  it('should be able to distinguish false alarms', async () => {
+    const content = `<script>
+    import _ from 'lodash';
+    const foo = "import bar from 'baz';";
+
+    let name = 'john doe';
+
+    $: formatted = _.capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'baz');
+
+    expect(result.length).toBe(0);
+  });
+
+  it('should be able to tolerate CommonJS import', async () => {
+    const content = `<script>
+    import _ from 'lodash';
+    const foo = require('bar');
+
+    let name = 'john doe';
+
+    $: formatted = _.capitalize(name);
+    </script>
+
+    <input bind:value={name} />
+
+    <h1>Hello, {formatted}!</h1>`;
+
+    const result = await getSvelteImportLines(content, 'bar');
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(3);
+  });
 });

--- a/__tests__/parser/ts.test.ts
+++ b/__tests__/parser/ts.test.ts
@@ -4,140 +4,140 @@ import { getTSImportLines } from '../../src/parser/ts';
 
 jest.useFakeTimers();
 
-afterEach(() => {
+afterEach(() =>{
   jest.clearAllTimers();
 });
 
-describe('TypeScript parser test', () => {
-  it('should be able to parse ES modules import', () => {
+describe('TypeScript parser test', () =>{
+  it('should be able to parse ES modules import', async () =>{
     const content = `import express from 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse all modules import', () => {
+  it('should be able to parse all modules import', async () =>{
     const content = `import * as express from 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse named imports', () => {
+  it('should be able to parse named imports', async () =>{
     const content = `import { json } from 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to aliased imports', () => {
+  it('should be able to aliased imports', async () =>{
     const content = `import { json as jeson } from 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse side-effect imports', () => {
+  it('should be able to parse side-effect imports', async () =>{
     const content = `import 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse type import', () => {
+  it('should be able to parse type import', async () =>{
     const content = `import type { Application } from 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse dynamic imports', () => {
+  it('should be able to parse dynamic imports', async () =>{
     const content = `const a = import('express');`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse CommonJS imports', () => {
+  it('should be able to parse CommonJS imports', async () =>{
     const content = `const a = require('express');`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(1);
   });
 
-  it('should be able to parse shebanged files', () => {
+  it('should be able to parse shebanged files', async () =>{
     const content = `#!/usr/bin/env node
 
     import express from 'express';`;
 
-    const dependant = getTSImportLines(content, 'express');
+    const dependant = await getTSImportLines(content, 'express');
 
     expect(dependant.length).toBe(1);
     expect(dependant[0]).toBe(3);
   });
 
-  it('should be able to parse module imports nested in code', () => {
-    const content = `(async () => {
+  it('should be able to parse module imports nested in code', async () =>{
+    const content = `(async () =>{
       if (somethingIsTrue) {
         await import('express');
       }
     })();`;
 
-    const dependants = getTSImportLines(content, 'express');
+    const dependants = await getTSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
 
-  it('should be able to parse actual TypeScript code', () => {
+  it('should be able to parse actual TypeScript code', async () =>{
     const content = `import express from 'express';
 
     const app: express.Application = express();
 
-    app.lister(3000, () => console.log('hello world'))`;
+    app.lister(3000, async () =>console.log('hello world'))`;
 
-    const dependants = getTSImportLines(content, 'express');
+    const dependants = await getTSImportLines(content, 'express');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to detect nested modules', () => {
+  it('should be able to detect nested modules', async () =>{
     const content = `import { defineConfig } from 'windicss/helpers';
 
     export default defineConfig({});`;
 
-    const dependants = getTSImportLines(content, 'windicss');
+    const dependants = await getTSImportLines(content, 'windicss');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to distinguish dash separated modules', () => {
+  it('should be able to distinguish dash separated modules', async () =>{
     const content = `import { defineConfig } from 'windicss-helpers';
 
     export default defineConfig({});`;
 
-    const dependants = getTSImportLines(content, 'windicss');
+    const dependants = await getTSImportLines(content, 'windicss');
     expect(dependants.length).toBe(0);
   });
 });
 
-describe('React TSX test', () => {
-  it('should be able to parse default imports', () => {
+describe('React TSX test', () =>{
+  it('should be able to parse default imports', async () =>{
     const content = `import React from 'react';
 
     export type HomeProps = {
@@ -151,12 +151,12 @@ describe('React TSX test', () => {
 
     export default Home;`;
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse default imports', () => {
+  it('should be able to parse default imports', async () =>{
     const content = `import * as React from 'react';
     import { useState } from 'react';
 
@@ -172,13 +172,13 @@ describe('React TSX test', () => {
 
     export default Home;`;
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(2);
     expect(dependants[0]).toBe(1);
     expect(dependants[1]).toBe(2);
   });
 
-  it('should be able to parse aliased imports', () => {
+  it('should be able to parse aliased imports', async () =>{
     const content = `import * as React from 'react';
     import { useState as a } from 'react';
 
@@ -194,13 +194,13 @@ describe('React TSX test', () => {
 
     export default Home;`
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(2);
     expect(dependants[0]).toBe(1);
     expect(dependants[1]).toBe(2);
   });
 
-  it('should be able to parse namespace imports', () => {
+  it('should be able to parse namespace imports', async () =>{
     const content = `import * as React from 'react';
 
     function Home(): JSX.Element {
@@ -209,12 +209,12 @@ describe('React TSX test', () => {
 
     export default Home;`
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse side-effect imports', () => {
+  it('should be able to parse side-effect imports', async () =>{
     const content = `import 'react';
 
     function Home(): JSX.Element {
@@ -223,12 +223,12 @@ describe('React TSX test', () => {
 
     export default Home;`
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse dynamic imports', () => {
+  it('should be able to parse dynamic imports', async () =>{
     const content = `const a = import('react');
 
     function Home(): JSX.Element {
@@ -237,16 +237,16 @@ describe('React TSX test', () => {
 
     export default Home;`
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to parse imports nested in code', () => {
+  it('should be able to parse imports nested in code', async () =>{
     const content = `import * as React from 'react';
 
     function Home(): JSX.Element {
-      const isTest = () => {
+      const isTest = () =>{
         if (isDevelopment) {
           const a = require('b');
         }
@@ -257,16 +257,16 @@ describe('React TSX test', () => {
 
     export default Home;`;
 
-    const dependants = getTSImportLines(content, 'b');
+    const dependants = await getTSImportLines(content, 'b');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(6);
   });
 
-  it('should be able to distinguish false alarms', () => {
+  it('should be able to distinguish false alarms', async () =>{
     const content = `const react = "import * as React from 'react';";
 
     function Home(): JSX.Element {
-      const isTest = () => {
+      const isTest = async () =>{
         if (isDevelopment) {
           const a = require('b');
         }
@@ -277,11 +277,11 @@ describe('React TSX test', () => {
 
     export default Home;`;
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(0);
   });
 
-  it('should be able to tolerate CommonJS imports', () => {
+  it('should be able to tolerate CommonJS imports', async () =>{
     const content = `import express from 'express';
 
     const react = require('react');
@@ -292,12 +292,12 @@ describe('React TSX test', () => {
 
     export default Home;`;
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(3);
   });
 
-  it('should be able to parse class-based components', () => {
+  it('should be able to parse class-based components', async () =>{
     const content = `import * as React from 'react';
 
     export class Welcome extends React.Component {
@@ -306,17 +306,17 @@ describe('React TSX test', () => {
       }
     }`;
 
-    const dependants = getTSImportLines(content, 'react');
+    const dependants = await getTSImportLines(content, 'react');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });
 
-  it('should be able to detect nested modules', () => {
+  it('should be able to detect nested modules', async () =>{
     const content = `import { defineConfig } from 'windicss/helpers';
 
     export default defineConfig({});`;
 
-    const dependants = getTSImportLines(content, 'windicss');
+    const dependants = await getTSImportLines(content, 'windicss');
     expect(dependants.length).toBe(1);
     expect(dependants[0]).toBe(1);
   });

--- a/__tests__/parser/vue.test.ts
+++ b/__tests__/parser/vue.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe('Vue parser test', () => {
-  it('should be able to parse ES module import', () => {
+  it('should be able to parse ES module import', async () => {
     const content = `<script>
     import Vue from 'vue';
 
@@ -28,13 +28,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse named imports', () => {
+  it('should be able to parse named imports', async () => {
     const content = `<script>
     import { ref } from 'vue';
 
@@ -53,13 +53,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse all module import', () => {
+  it('should be able to parse all module import', async () => {
     const content = `<script>
     import * as Vue from 'vue';
 
@@ -78,13 +78,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse aliased imports', () => {
+  it('should be able to parse aliased imports', async () => {
     const content = `<script>
     import { ref as foo } from 'vue';
 
@@ -103,13 +103,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse side-effect imports', () => {
+  it('should be able to parse side-effect imports', async () => {
     const content = `<script>
     import { ref } from 'vue';
     import 'foo/dist/bar.css';
@@ -129,13 +129,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'foo');
+    const result = await getVueImportLines(content, 'foo');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(3);
   });
 
-  it('should be able to parse dynamic imports', () => {
+  it('should be able to parse dynamic imports', async () => {
     const content = `<script>
     import { ref } from 'vue';
 
@@ -158,13 +158,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'baz');
+    const result = await getVueImportLines(content, 'baz');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(5);
   });
 
-  it('should be able to distinguish false alarms', () => {
+  it('should be able to distinguish false alarms', async () => {
     const content = `<script>
     import { ref } from 'vue';
     const foo = 'import bar from "baz";';
@@ -184,12 +184,12 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'baz');
+    const result = await getVueImportLines(content, 'baz');
 
     expect(result.length).toBe(0);
   });
 
-  it('should be able to tolerate CommonJS import', () => {
+  it('should be able to tolerate CommonJS import', async () => {
     const content = `<script>
     const vue = require('vue');
 
@@ -208,13 +208,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse TypeScript based script', () => {
+  it('should be able to parse TypeScript based script', async () => {
     const content = `<script lang="ts">
     import { ref, Ref } from 'vue';
 
@@ -233,13 +233,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse TypeScript type imports', () => {
+  it('should be able to parse TypeScript type imports', async () => {
     const content = `<script lang="ts">
     import { ref } from 'vue';
     import type { Ref } from 'vue';
@@ -259,14 +259,14 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'vue');
+    const result = await getVueImportLines(content, 'vue');
 
     expect(result.length).toBe(2);
     expect(result[0]).toBe(2);
     expect(result[1]).toBe(3);
   });
 
-  it('should be able to parse `script setup`', () => {
+  it('should be able to parse `script setup`', async () => {
     const content = `<script setup>
     import _ from 'lodash';
 
@@ -277,13 +277,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'lodash');
+    const result = await getVueImportLines(content, 'lodash');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse Options API', () => {
+  it('should be able to parse Options API', async () => {
     const content = `<script>
     import _ from 'lodash';
 
@@ -294,7 +294,7 @@ describe('Vue parser test', () => {
         };
       },
       computed: {
-        formattedName: () => {
+        formattedName: async () => {
           return _.capitalize(this.name);
         },
       },
@@ -308,13 +308,13 @@ describe('Vue parser test', () => {
       Hello, {{ name }}
     </template>`;
 
-    const result = getVueImportLines(content, 'lodash');
+    const result = await getVueImportLines(content, 'lodash');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(2);
   });
 
-  it('should be able to parse class components', () => {
+  it('should be able to parse class components', async () => {
     // straightly copy pasted from class component example
     const content = `<template>
       <div>
@@ -343,7 +343,7 @@ describe('Vue parser test', () => {
     }
     </script>`;
 
-    const result = getVueImportLines(content, 'vue-class-component');
+    const result = await getVueImportLines(content, 'vue-class-component');
 
     expect(result.length).toBe(1);
     expect(result[0]).toBe(11);

--- a/__tests__/project.test.ts
+++ b/__tests__/project.test.ts
@@ -19,12 +19,12 @@ describe('Parser tolerance test', () => {
       },
     ];
 
-    expect(() => getDependantFiles(files, 'express', {
+    expect(getDependantFiles(files, 'express', {
       silent: false,
-    })).toThrowError('Failed to parse src/a.js');
+    })).rejects.toBeTruthy();
   });
 
-  it('should not throw an error when silent is true', () => {
+  it('should not throw an error when silent is true', async () => {
     const files: ProjectFile[] = [
       {
         name: 'a.js',
@@ -33,7 +33,7 @@ describe('Parser tolerance test', () => {
       },
     ];
 
-    const dependants = getDependantFiles(files, 'express', {
+    const dependants = await getDependantFiles(files, 'express', {
       silent: true,
     });
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "rollup-plugin-typescript2": "^0.30.0",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
+    "svelte": "^3.42.4",
     "ts-jest": "^27.0.5",
     "typescript": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
     "svelte": "^3.42.4",
+    "svelte-preprocess": "^4.8.0",
     "ts-jest": "^27.0.5",
     "typescript": "^4.3.5"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,12 +27,14 @@ export const cli = yargs(process.argv.slice(2))
       '!(node_modules)/**/*.jsx',
       '!(node_modules)/**/*.tsx',
       '!(node_modules)/**/*.vue',
+      '!(node_modules)/**/*.svelte',
       '*.js',
       '*.mjs',
       '*.ts',
       '*.jsx',
       '*.tsx',
       '*.vue',
+      '*.svelte',
     ],
   })
   .options({

--- a/src/import.ts
+++ b/src/import.ts
@@ -42,7 +42,6 @@ export async function getDependantFiles(
         return null;
       } catch (err) {
         const error = err as Error;
-        console.error(error);
         throw new Error(`Failed to parse ${file.path}: ${error.message}`);
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { showDependantFiles } from './logger';
 
     spinner.text = chalk.greenBright('Analyzing package dependency...');
 
-    const dependant = getDependantFiles(
+    const dependant = await getDependantFiles(
       files,
       dependency,
       {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,7 @@
 import { FileParser } from '../types';
 
 import { getJSImportLines } from './js';
+import { getSvelteImportLines } from './svelte';
 import { getTSImportLines } from './ts';
 import { getVueImportLines } from './vue';
 
@@ -14,6 +15,7 @@ const PARSER_FUNCTIONS: Record<string, FileParser> = {
   jsx: getJSImportLines,
   tsx: getTSImportLines,
   vue: getVueImportLines,
+  svelte: getSvelteImportLines,
 };
 
 /**

--- a/src/parser/js.ts
+++ b/src/parser/js.ts
@@ -21,10 +21,7 @@ const parser = Parser.extend(jsx());
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function parseNode(
-  sourceNode: Node,
-  dependency: string,
-): number[] {
+export function parseNode(sourceNode: Node, dependency: string): number[] {
   const lines: number[] = [];
 
   simple(sourceNode, {
@@ -80,10 +77,10 @@ export function parseNode(
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function getJSImportLines(
+export async function getJSImportLines(
   content: string,
   dependency: string,
-): number[] {
+): Promise<number[]> {
   const node: Node = parser.parse(content, {
     ecmaVersion: 'latest',
     locations: true,

--- a/src/parser/js.ts
+++ b/src/parser/js.ts
@@ -21,7 +21,7 @@ const parser = Parser.extend(jsx());
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function parseNode(sourceNode: Node, dependency: string): number[] {
+function parseNode(sourceNode: Node, dependency: string): number[] {
   const lines: number[] = [];
 
   simple(sourceNode, {

--- a/src/parser/svelte.ts
+++ b/src/parser/svelte.ts
@@ -9,7 +9,6 @@ import type {
 } from 'estree';
 import type { BaseNode } from 'estree-walker';
 
-
 let svelte: typeof import('svelte/compiler');
 
 try {
@@ -47,7 +46,6 @@ try {
 } catch (err) {
   /* ignore for now */
 }
-
 
 /**
  * Parse native JavaScript nodes for imports to `dependency`

--- a/src/parser/svelte.ts
+++ b/src/parser/svelte.ts
@@ -1,0 +1,42 @@
+import globalDirectories from 'global-dirs';
+import path from 'path';
+
+let svelte: typeof import('svelte/compiler');
+
+try {
+  const basePath = [
+    'svelte',
+    'compiler.mjs',
+  ];
+  const localPath = new URL(
+    path.posix.resolve('node_modules', ...basePath),
+    import.meta.url,
+  );
+  const npmPath = new URL(
+    path.posix.resolve(globalDirectories.npm.packages, ...basePath),
+    import.meta.url,
+  );
+  const yarnPath = new URL(
+    path.posix.resolve(globalDirectories.yarn.packages, ...basePath),
+    import.meta.url,
+  );
+
+  const imports = await Promise.allSettled([
+    import(localPath.toString()),
+    import(npmPath.toString()),
+    import(yarnPath.toString()),
+  ]);
+
+  for (let i = 0; i < imports.length; i++) {
+    const impor = imports[i];
+
+    if (impor.status === 'fulfilled') {
+      svelte = impor.value.default as typeof import('svelte/compiler');
+      break;
+    } else {
+      console.log (impor.reason);
+    }
+  }
+} catch (err) {
+  /* ignore for now */
+}

--- a/src/parser/svelte.ts
+++ b/src/parser/svelte.ts
@@ -1,42 +1,133 @@
 import globalDirectories from 'global-dirs';
 import path from 'path';
 
+import type {
+  ImportDeclaration,
+  ImportExpression,
+  CallExpression,
+  SourceLocation
+} from 'estree';
+import type { BaseNode } from 'estree-walker';
+
+
 let svelte: typeof import('svelte/compiler');
 
 try {
-  const basePath = [
+  const baseCompilerPath = [
     'svelte',
-    'compiler.mjs',
+    'compiler.js',
   ];
-  const localPath = new URL(
-    path.posix.resolve('node_modules', ...basePath),
+  const localCompilerPath = new URL(
+    path.posix.resolve('node_modules', ...baseCompilerPath),
     import.meta.url,
   );
-  const npmPath = new URL(
-    path.posix.resolve(globalDirectories.npm.packages, ...basePath),
+  const npmCompilerPath = new URL(
+    path.posix.resolve(globalDirectories.npm.packages, ...baseCompilerPath),
     import.meta.url,
   );
-  const yarnPath = new URL(
-    path.posix.resolve(globalDirectories.yarn.packages, ...basePath),
+  const yarnCompilerPath = new URL(
+    path.posix.resolve(globalDirectories.yarn.packages, ...baseCompilerPath),
     import.meta.url,
   );
 
-  const imports = await Promise.allSettled([
-    import(localPath.toString()),
-    import(npmPath.toString()),
-    import(yarnPath.toString()),
+  const compilerImports = await Promise.allSettled([
+    import(localCompilerPath.toString()),
+    import(npmCompilerPath.toString()),
+    import(yarnCompilerPath.toString()),
   ]);
 
-  for (let i = 0; i < imports.length; i++) {
-    const impor = imports[i];
+  for (let i = 0; i < compilerImports.length; i++) {
+    const impor = compilerImports[i];
 
     if (impor.status === 'fulfilled') {
       svelte = impor.value.default as typeof import('svelte/compiler');
       break;
-    } else {
-      console.log (impor.reason);
     }
   }
 } catch (err) {
   /* ignore for now */
+}
+
+
+/**
+ * Parse native JavaScript nodes for imports to `dependency`
+ *
+ * @param {Node} sourceNode AST representation of the file
+ * @param {string} dependency Package name
+ * @returns {number[]} List of line numbers where `dependency`
+ * is imported.
+ */
+export function parseNode(sourceNode: BaseNode, dependency: string): number[] {
+  const lines: number[] = [];
+
+  svelte.walk(sourceNode, {
+    enter(node) {
+      switch (node.type) {
+        case 'ImportDeclaration': {
+          const importDec = node as ImportDeclaration;
+
+          if (
+            importDec.source.type === 'Literal' &&
+            importDec.source.value?.toString().split('/')[0] === dependency
+          ) {
+            lines.push((node.loc as SourceLocation).start.line);
+          }
+
+          break;
+        }
+        case 'ImportExpression': {
+          const importExpr = node as ImportExpression;
+
+          if (
+            importExpr.source.type === 'Literal' &&
+            importExpr.source.value?.toString().split('/')[0] === dependency
+          ) {
+            lines.push((node.loc as SourceLocation).start.line);
+          }
+
+          break;
+        }
+
+        case 'CallExpression': {
+          const callExpr = node as CallExpression;
+
+          if (
+            callExpr.callee.type === 'Identifier' &&
+            callExpr.callee.name === 'require' &&
+            callExpr.arguments[0].type === 'Literal' &&
+            callExpr.arguments[0].value?.toString().split('/')[0] === dependency
+          ) {
+            lines.push((node.loc as SourceLocation).start.line);
+          }
+
+          break;
+        }
+      }
+    }
+  })
+
+  return lines;
+}
+
+/**
+ * Analyze Svelte file for all imports to `dependency`
+ *
+ * @param {string} content File content
+ * @param {string} dependency Package name
+ * @returns {number[]} List of line numbers where `dependency`
+ * is imported.
+ */
+export async function getSvelteImportLines(
+  content: string,
+  dependency: string,
+): Promise<number[]> {
+  if (!svelte) {
+    throw new Error('No Svelte parsers available');
+  }
+
+  const node = svelte.parse(content);
+  return [
+    ...parseNode(node.instance, dependency),
+    ...parseNode(node.module, dependency),
+  ];
 }

--- a/src/parser/ts.ts
+++ b/src/parser/ts.ts
@@ -51,10 +51,7 @@ try {
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-function parseNode(
-  sourceNode: SourceFile,
-  dependency: string,
-): number[] {
+function parseNode(sourceNode: SourceFile, dependency: string): number[] {
   const lineNumbers: number[] = [];
 
   const walk = (node: Node) => {
@@ -118,10 +115,10 @@ function parseNode(
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function getTSImportLines(
+export async function getTSImportLines(
   content: string,
   dependency: string,
-): number[] {
+): Promise<number[]> {
   if (!ts) {
     throw new Error('No Typescript parsers available');
   }

--- a/src/parser/ts.ts
+++ b/src/parser/ts.ts
@@ -31,7 +31,9 @@ try {
     import(yarnPath.toString()),
   ]);
 
-  for (const impor of imports) {
+  for (let i = 0; i < imports.length; i++) {
+    const impor = imports[i];
+
     if (impor.status === 'fulfilled') {
       ts = impor.value.default as typeof import('typescript');
       break;

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -31,7 +31,9 @@ try {
     import(yarnPath.toString()),
   ]);
 
-  for (const impor of imports) {
+  for (let i = 0; i < imports.length; i++) {
+    const impor = imports[i];
+
     if (impor.status === 'fulfilled') {
       vue = impor.value.default as typeof import('@vue/compiler-sfc');
       break;

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -37,8 +37,6 @@ try {
     if (impor.status === 'fulfilled') {
       vue = impor.value.default as typeof import('@vue/compiler-sfc');
       break;
-    } else {
-      console.log (impor.reason);
     }
   }
 } catch (err) {
@@ -53,10 +51,10 @@ try {
  * @returns {number[]} List of line numbers where `dependency`
  * is imported.
  */
-export function getVueImportLines(
+export async function getVueImportLines(
   content: string,
   dependency: string,
-): number[] {
+): Promise<number[]> {
   if (!vue) {
     throw new Error('No Vue parsers available');
   }
@@ -68,7 +66,7 @@ export function getVueImportLines(
     const startingLine = script.loc.start.line;
     const parser = getParser(script.lang || 'js');
 
-    const lines = parser(script.content, dependency);
+    const lines = await parser(script.content, dependency);
     // -1, since the `<script>` block shouldn't count
     return lines.map(line => line + startingLine - 1);
   }

--- a/src/parser/vue.ts
+++ b/src/parser/vue.ts
@@ -64,6 +64,10 @@ export async function getVueImportLines(
 
   if (script) {
     const startingLine = script.loc.start.line;
+    if (script.lang === 'vue') {
+      throw new Error('Circular parser dependency');
+    }
+
     const parser = getParser(script.lang || 'js');
 
     const lines = await parser(script.content, dependency);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,4 +27,4 @@ export interface ParserOptions {
 export type FileParser = (
   content: string,
   dependency: string,
-) => number[];
+) => Promise<number[]>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,6 +1029,18 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
   integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
+"@types/pug@^2.0.4":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.5.tgz#69bc700934dd473c7ab97270bd2dbacefe562231"
+  integrity sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==
+
+"@types/sass@^1.16.0":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.1.tgz#cf465bd1fea486d0331f760db023de14daf4980d"
+  integrity sha512-iZUcRrGuz/Tbg3loODpW7vrQJkUtpY2fFSf4ELqqkApcS2TkZ1msk7ie8iZPB86lDOP8QOTTmuvWjc5S0R9OjQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -2033,6 +2045,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+detect-indent@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
+  integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -5430,6 +5447,16 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+svelte-preprocess@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.8.0.tgz#fd3ebc19aae1b8a49ac9e30db1af572bf4619245"
+  integrity sha512-i9Z17cwGlp+kuSSv3kJWdAdAP2L26A5yMzHHdDj8YL+86sN64Yz5/gfjQp3Xb6fiaToo4sB+wTpid/23Gz0yvw==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    strip-indent "^3.0.0"
 
 svelte@^3.42.4:
   version "3.42.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5431,6 +5431,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+svelte@^3.42.4:
+  version "3.42.4"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.42.4.tgz#838ed98fa7b26fc5fffe4df0d7ba345f1c54cf4f"
+  integrity sha512-DqC0AmDdBrrbIA+Kzl3yhBb6qCn4vZOAfxye2pTnIpinLegyagC5sLI8Pe9GPlXu9VpHBXIwpDDedpMfu++epA==
+
 svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"


### PR DESCRIPTION
## Overview

Closes #39 

This pull request adds SvelteJS out-of-the-box support to `dependent`. Now, `dependent` is able to parse `.svelte` files.

### Tasks

- [x] Implement `.svelte` parser
- [x] Test the functionalities

### Caveats

Only `.js` files are supported at the moment. We will dig in into `svelte-preprocess` later.
