### PR TITLE
feat: Add categorized logging to dependant files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,25 @@ After the command is given, `dependent` will produce a list of dependant files i
 ✔ Analysis completed successfully
 
 📦 There are 17 files in this project that depends on 'phaser'
- └── index.ts:1 → src/index.ts
- └── cherry.ts:1 → src/objects/cherry.ts
- └── flyer.ts:1 → src/objects/flyer.ts
- └── mushroom.ts:1 → src/objects/mushroom.ts
- └── player.ts:1 → src/objects/player.ts
- └── saw.ts:1 → src/objects/saw.ts
- └── spike.ts:1 → src/objects/spike.ts
- └── trophy.ts:1 → src/objects/trophy.ts
- └── game.ts:1 → src/scenes/game.ts
- └── pause.ts:1 → src/scenes/pause.ts
- └── preload.ts:1 → src/scenes/preload.ts
- └── result.ts:1 → src/scenes/result.ts
- └── splash.ts:1 → src/scenes/splash.ts
- └── title.ts:1 → src/scenes/title.ts
- └── assets.ts:1 → src/utils/assets.ts
- └── background.ts:1 → src/utils/background.ts
- └── ui.ts:1 → src/utils/ui.ts
+
+📁 TypeScript Files
+└── index.ts:1 → src/index.ts
+└── assets.ts:1 → src/utils/assets.ts
+└── background.ts:1 → src/utils/background.ts
+└── cherry.ts:1 → src/objects/cherry.ts
+└── flyer.ts:1 → src/objects/flyer.ts
+└── game.ts:1 → src/scenes/game.ts
+└── mushroom.ts:1 → src/objects/mushroom.ts
+└── pause.ts:1 → src/scenes/pause.ts
+└── player.ts:1 → src/objects/player.ts
+└── preload.ts:1 → src/scenes/preload.ts
+└── result.ts:1 → src/scenes/result.ts
+└── saw.ts:1 → src/objects/saw.ts
+└── spike.ts:1 → src/objects/spike.ts
+└── splash.ts:1 → src/scenes/splash.ts
+└── title.ts:1 → src/scenes/title.ts
+└── trophy.ts:1 → src/objects/trophy.ts
+└── ui.ts:1 → src/utils/ui.ts
 ```
 
 Congratulation, you've used `dependent` successfully! 🎉
@@ -109,8 +111,7 @@ Dependency name to be analyzed. Must be defined in `package.json` and installed 
 
 A list of glob patterns that specifies the directories to be analyzed. Space separated.
 
-For example, the argument below will make `dependent` to analyze all JavaScript files that dependes on `express`
-in `src` and `lib` directory.
+For example, the argument below will make `dependent` to analyze all JavaScript files that depends on `express` in `src` and `lib` directory.
 
 ```bash
 dependent express src/**/*.js lib/**/*.js
@@ -120,25 +121,25 @@ dependent express src/**/*.js lib/**/*.js
 
 ### `--help`, `-h`
 
-Show the help menu
+Show the help menu.
 
 ### `--silent`, `-s`
 
-Suppress all parsing errors.
+Suppress all parsing errors. Default: `false`
 
 ### `--table`, `-t`
 
-Outputs the result in table-style format instead of line per line format.
+Outputs the result in table-style format instead of line per line format. Default `false`
 
 ## FAQ
 
 ### My vue files cannot be parsed. Help!
 
-`dependent` will only support Vue 3 projects. If you asking me to support Vue 2, then the answer is
+`dependent` will only support Vue 3 projects. I don't plan to add Vue 2 support as Vue 3 is already stable. Feel free to create PR for this though!
 
-![No, I don't think I will](https://i.ytimg.com/vi/WIiHrfQq-bo/maxresdefault.jpg)
+### `dependent` does not support TypeScript on Svelte files!
 
-Vue 3 is already stable, there's no reason to support Vue 2 at all. Feel free to create PR for this though!
+Svelte compiler won't parse anything that is not a JavaScript. Technically, this can be mitigated by doing preprocessing steps like compilation or transpilation. However, this may lead to inaccurate analysis as the code changes which leads to line number changes. We are still looking for the best solution for this.
 
 ## Motivation
 

--- a/__tests__/project.test.ts
+++ b/__tests__/project.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 
 import { getDependantFiles } from '../src/import';
-import { ProjectFile } from './../src/types';
+import { ProjectFile } from './../src/constants/types';
 
 jest.useFakeTimers();
 

--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -8,6 +8,6 @@ export const FILE_TYPES = {
   jsx: 'React\'s Extended JavaScript Files',
   ts: 'TypeScript Files',
   tsx: 'React\'s TypeScript Component',
-  vue: 'Vue Single File Component',
-  svelte: 'Svelte Single File Component',
+  vue: 'Vue\'s Single File Component',
+  svelte: 'Svelte\'s Single File Component',
 };

--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -1,0 +1,13 @@
+/**
+ * File extension with their description.
+ * Used when logging the result to console.
+ */
+export const FILE_TYPES = {
+  js: 'JavaScript Files',
+  mjs: 'ESModule Files',
+  jsx: 'React\'s Extended JavaScript Files',
+  ts: 'TypeScript Files',
+  tsx: 'React\'s TypeScript Component',
+  vue: 'Vue Single File Component',
+  svelte: 'Svelte Single File Component',
+};

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Package json definition for the current working directory.
+ */
 export interface ProjectDefinition {
   name: string;
   dependencies: Record<string, string>;
@@ -5,18 +8,28 @@ export interface ProjectDefinition {
   peerDependencies: Record<string, string>;
 }
 
+/**
+ * A file that is dependant to the target dependency.
+ */
 export interface DependantFile {
   name: string;
   path: string;
   lineNumbers: number[];
 }
 
+/**
+ * A matching file in the current directory.
+ */
 export interface ProjectFile {
   name: string;
   path: string;
   content: string;
 }
 
+/**
+ * Options to be passed when analyzing imports to
+ * target dependency.
+ */
 export interface ParserOptions {
   silent: boolean;
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,7 +3,7 @@ import glob from 'glob';
 import { readFileSync } from 'fs';
 import { basename } from 'path';
 
-import { ProjectFile } from './types';
+import { ProjectFile } from './constants/types';
 
 /**
  * Get all files in the project directory that matches

--- a/src/import.ts
+++ b/src/import.ts
@@ -2,7 +2,11 @@ import chalk from 'chalk';
 
 import { getParser } from './parser';
 
-import type { DependantFile, ParserOptions, ProjectFile } from './types';
+import type {
+  DependantFile,
+  ParserOptions,
+  ProjectFile,
+} from './constants/types';
 
 /**
  * Analyze all relevant files for imports to `dependency`

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { DependantFile } from './types';
+import { DependantFile } from './constants/types';
 
 /**
  * Outputs all dependant files to `stdout` in table

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -64,7 +64,7 @@ function categorize(files: DependantFile[]): Record<string, DependantFile[]> {
  * @param {DependantFile[]} files Dependant files
  */
 function logTable(files: DependantFile[]): void {
-  const tableFriendlyObjects = files.map((file) => {
+  const tableFriendlyFiles = files.map((file) => {
     return {
       'File name': file.name,
       'File path': file.path,
@@ -72,27 +72,27 @@ function logTable(files: DependantFile[]): void {
     };
   });
 
-  console.table(tableFriendlyObjects);
+  console.table(tableFriendlyFiles);
 }
 
 /**
  * Outputs all dependant files to `stdout` in line-per-line
  * format.
  *
- * @param {DependantFile[]} files Dependant files
+ * @param {DependantFile[]} files Dependant files.
  */
 function logLines(files: DependantFile[]): void {
   files.forEach(({ name, path, lineNumbers }) => {
     console.log(
       chalk.cyan(
-        ` └── ${name}:${lineNumbers.join(', ')} → ${path}`,
+        `└── ${name}:${lineNumbers.join(', ')} → ${path}`,
       ),
     )
   });
 }
 
 /**
- * Outputs all dependant files to `stdout`
+ * Outputs all dependant files to `stdout` with `console`
  *
  * @param {DependantFile[]} files Dependant files
  * @param {string} dependency Package name
@@ -111,9 +111,18 @@ export function showDependantFiles(
     ),
   );
 
-  const fileMaps = categorize(files);
-
   if (files.length) {
-    table ? logTable(files) : logLines(files);
+    console.log(); // new line
+    const fileMaps = categorize(files);
+
+    for (const [ext, files] of Object.entries(fileMaps)) {
+      const alias = FILE_TYPES[ext as keyof typeof FILE_TYPES];
+
+      if (files.length) {
+        console.log(`📁 ${alias}`);
+        table ? logTable(files) : logLines(files);
+        console.log(); // empty lines
+      }
+    }
   }
 }

--- a/src/package.ts
+++ b/src/package.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { spawn } from 'child_process';
 
-import { ProjectDefinition } from './types';
+import { ProjectDefinition } from './constants/types';
 
 /**
  * Get all information of the project from `package.json`

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,4 +1,4 @@
-import { FileParser } from '../types';
+import { FileParser } from '../constants/types';
 
 import { getJSImportLines } from './js';
 import { getSvelteImportLines } from './svelte';


### PR DESCRIPTION
## Overview

Closes #41 

This pull request adds a categorized reporting system to `dependent` when reporting the result. Categorization is achieved by structuring the data with two sorting criteria.

First, all dependant files will be sorted by their file extension. After the files are separated by their extension, all files will be sorted by their directory depth. Both sorts are in ascending order.

### Tasks

- [x] Design a better-structured result reporting
- [x] Implement the features
- [x] Test the features
