### PR TITLE
fix(ci): prioritize setup-pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install dependencies
-        run: pnpm install
       - name: Setup PNPM
         uses: pnpm/action-setup@v2.1.0
         with:
           version: 7.0.0
+      - name: Install dependencies
+        run: pnpm install
       - name: Lint and test before release
         run: pnpm run lint:fix && pnpm run test
       - name: Release


### PR DESCRIPTION
## Overview

Closes #45 

This pull request fixes CI pipeline by prioritizing `@actions/setup-pnpm` first after `@actions/setup-node`
