### PR TITLE
fix(cli): add 's' to default cli values for include option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,7 @@ export const cli = yargs(process.argv.slice(2))
     include: {
       describe: 'Type of possible dependant to be scanned for dependency. Defaults to files and scripts',
       type: 'array',
-      default: ['script', 'file'],
+      default: ['scripts', 'files'],
       demandOption: false,
     },
   });


### PR DESCRIPTION
## Overview

Closes #54 

This pull request replaces the default value of `include` from `['file', 'script']` to `['files', 'scripts']` (notice the 's') as intended.
