### PR TITLE
fix(vue): add new compiler spec path for vue 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 > This project is still on active development. The API ***might** change without further notice.
 
-> This project currently doesn't work if your project is managed by pnpm. See [this issue](https://github.com/Namchee/dependent/issues/56) for more information.
-
 Dependent is a simple utility CLI to find out which files in your NodeJS-based projects are using a certain dependency. 🚀
 
 ![Demo](docs/demo.gif)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,5 +25,6 @@ export default {
     'acorn',
     'acorn-walk',
     'acorn-jsx',
+    'table',
   ]
 }

--- a/src/service/parser/vue.ts
+++ b/src/service/parser/vue.ts
@@ -19,16 +19,24 @@ export async function loadVueCompiler(globs: string[]): Promise<void> {
     return;
   }
 
-  const compilerPath = [
+  const oldCompilerPath = [
     '@vue',
     'compiler-sfc',
     'dist',
     'compiler-sfc.cjs.js',
   ];
 
+  // For Vue 3.2+
+  const newCompilerPath = [
+    'vue',
+    'compiler-sfc',
+    'index.js',
+  ];
+
   const paths = [
-    resolve(process.cwd(), 'node_modules', ...compilerPath),
-    ...globs.map(path => resolve(path, ...compilerPath)),
+    resolve(process.cwd(), 'node_modules', ...newCompilerPath),
+    resolve(process.cwd(), 'node_modules', ...oldCompilerPath),
+    ...globs.map(path => resolve(path, ...oldCompilerPath)),
   ];
 
   const imports = paths.map(path => import(pathToFileURL(path).toString()));


### PR DESCRIPTION
## Overview

Closes #56 

This pull request fixes `dependent` behavior when executed on pnpm-managed projects by adding new compiler spec specifically for vue. 

### Caveats

Still doesn't fix the bug if Vue is on v3.1 or older, but we should support latest stuff for this toy project.
